### PR TITLE
Dockerfile: add libcap-ng-dev for qemu virtfs support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get -y --allow-downgrades --allow-remove-essential --allow-change-held-p
 	gdisk \
 	libattr1-dev \
 	libcap-dev \
+	libcap-ng-dev \
 	libfdt-dev \
 	libftdi-dev \
 	libglib2.0-dev \


### PR DESCRIPTION
When QEMU shared folders feature is enabled (through QEMU_VIRTFS_ENABLE option) then QEMU is configured with the parameter --enable-virtfs which requires libcap-ng-dev package.

Without this package, it produces this error:

> ../meson.build:1467:0: ERROR: Feature virtfs cannot be enabled: virtio-9p (virtfs) on Linux requires libcap-ng-devel and libattr-devel

Steps to reproduce (inside docker image):
```
cd build
make QEMU_VIRTFS_AUTOMOUNT=y qemu
```