### PR TITLE
PR to update README - Workarounds for MacOS xterm,  Docker build issue, and root access

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,44 @@ $ docker start silly_bhaskara
 # Finally re-attach to the running container
 $ docker attach silly_bhaskara
 ```
+
+### Additional Xterm Help
+Once you run the docker run command above and are at the '/home/optee/qemu-optee' 
+command line, you run the `./launch_optee.sh` script and you get an error about 
+not being able to find the xterm (xQuartz) server that looks like this
+```bash
+* QEMU is now waiting to start the execution
+* Start execution with either a 'c' followed by <enter> in the QEMU console or
+* attach a debugger and continue from there.
+*
+* To run OP-TEE tests, use the xtest command in the 'Normal World' terminal
+* Enter 'xtest -h' for help.
+
+xterm: Xt error: Can't open display: /private/tmp/com.apple.launchd.CuNDWxl9fm/org.xquartz:0
+xterm: Xt error: Can't open display: /private/tmp/com.apple.launchd.CuNDWxl9fm/org.xquartz:0
+``` 
+you don't need to restart the container to fix it. First, press CNTRL-c. 
+
+Try `export DISPLAY=host.docker.internal:0` at the command line and follow that 
+with `make run`. The use of `export DISPLAY=host.docker.internal:0` came from 
+this conversation 
+https://gist.github.com/cschiewek/246a244ba23da8b9f0e7b11a68bf3285?permalink_comment_id=3477013#gistcomment-3477013
+
+### Troubleshooting Docker Build
+If you have built the image more than once and start to get strange errors that a 
+package can't be found (acts like you haven't run `apt-get update`) try pruning 
+the builder cache like this.
+```bash
+$ docker builder prune
+```
+Then try building again. The issue is that the previous `apt-get update` has 
+gotten cached and the `docker builder prune` clears that cache.
+
+### Getting Root at the Docker Run Commandline
+After you execute the docker run command (as above) you will be put into a command 
+line where the toolchain and the QEMU environment will be built and run.  
+At the `/qemu-optee$ ` prompt if you run the `whoami` you will be `optee`.  
+If you need to be root (IDK: to add a package) the way to get that access is to 
+access the container again using `docker exec -it -u 0 <container_name> /bin/bash` where 
+you would replace `<container_name>` with the container name you would find by 
+doing the `docker ps` command. This should give you root access.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ gotten cached and the `docker builder prune` clears that cache.
 
 ### Getting Root at the Docker Run Commandline
 After you execute the docker run command (as above) you will be put into a command 
-line where the toolchain and the QEMU environment will be built and run.  
+line where the toolchain and the QEMU environment will be built and run. 
 At the `/qemu-optee$ ` prompt if you run the `whoami` you will be `optee`.  
 If you need to be root (IDK: to add a package) the way to get that access is to 
 access the container again using `docker exec -it -u 0 <container_name> /bin/bash` where 


### PR DESCRIPTION
I modified the README to provide work arounds for a few things I ran into.

MacOS xterm issue when env DISPLAY isn't set properly (might work on other OS assuming that the Xterm server is on the host of the docker container). 

I found myself rebuilding the docker image when trying stuff out.  It would fail because a change in the in the package repo was being overlook as the `apt-get update` was cached.

Root access, added how to work around getting root as I saw someone else asking.  